### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,18 @@
 ---
-name: Release
+name: "Release"
 on:
   workflow_dispatch:
   pull_request_target:
     types: [closed]
     branches: [main]
-permissions:
-  contents: read
 jobs:
   release:
     permissions:
       contents: write
       pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@6bc46d499c518406c22e58ac9b61a05c0b654985
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  release_image:
-    needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@26eec20abba5ae806698592c79628f6906da372c
-    with:
-      image-name: ${{ github.repository }}
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      short-tag: ${{ needs.release.outputs.short-tag }}
-      create-attestation: true
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
-      image-registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530). Drop the separate release-image job now that container image build/attestation is folded into the reusable workflow. Add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Surfacing breaking changes prominently in release notes aligns the changelog with the new label-based release triggers.

## Notes

- The outer label-filter `if:` block is removed because the v1.0 reusable workflow now handles label filtering internally.
- Trigger remains `pull_request_target` so the workflow can push tags via `GITHUB_TOKEN`.
- The standalone `release_image` job was removed because v1.0 of the reusable workflow now performs container image build and attestation internally.
- This repository serves as one of the test harnesses for `github-community-projects/ospo-reusable-workflows`, so merging here exercises the v1.0.0 path end-to-end.

## Testing

- Merge a PR labeled `breaking`, `feature`, `vuln`, or `release` against `main` and confirm the reusable workflow drafts/publishes a release with the correct version bump.
- Verify the Breaking Changes category renders in the drafted release notes when a `breaking`-labeled PR is included.
- Confirm the container image is built, pushed, and attested by the reusable workflow (no separate `release_image` job required).