### PR TITLE
fix: restore container image build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,17 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate build provenance attestations
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
+      image-name: ${{ github.repository }}
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Add `image-name: ${{ github.repository }}` input, `packages: write` permission, and the `image-registry-password` secret so the v1.0.0 reusable workflow publishes the container image. The previous PR (#3) removed the standalone `release_image` job without re-wiring image-name on the reusable workflow inputs, which silently dropped image publishing.

## Why

In v1.0.0 of `ospo-reusable-workflows`, container image publishing is gated on the `image-name` input being set. Removing the standalone `release_image` job is correct, but the reusable workflow needs `image-name` to be passed in to keep behaving identically.

## Notes

- This repo exercises the reusable workflow end-to-end, so the image step needs to remain wired up for parity with prior test runs.
- `create-attestation: true` is also added so attestation behavior matches the prior `release_image` job.

## Testing

After this lands, trigger the release workflow via workflow_dispatch and confirm the image is published under `ghcr.io/jmeridth/test-ospo-reusable-workflows`.