### PR TITLE
fix: declare full v1.0 permission set on release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       packages: write       # Push container image to ghcr.io
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true


### PR DESCRIPTION
## What

Add discussions: write to the release job's permissions block. v1.0 of ospo-reusable-workflows/release.yaml declares it on its internal release_discussion job, and GitHub validates it at workflow startup regardless of whether the if: filter would skip the job.

## Why

PRs #3 and #4 bumped the caller to v1.0 but didn't include the discussions permission. The Release workflow now fails on merge with startup_failure. Aligning the caller's release job permissions with the ospo/stale-repos reference fixes the validation.

## Notes

- discussions: write is required by GitHub's static validation even when create-discussion is false and the release_discussion job would be skipped.
- This repo is a test harness for ospo-reusable-workflows itself, so keeping the workflow runnable is the whole point.

## Testing

After merging, the next merged PR will trigger a successful Release workflow startup (no more startup_failure).