### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
       discussions: write    # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml


### PR DESCRIPTION
## What

Bump the pin on ospo-reusable-workflows/release.yaml from v1.0.0 to v1.0.1 (SHA e92cb6053ace495fe40a5f185988557afcdcecbc).

## Why

v1.0.1 lands two fixes from upstream PR github-community-projects/ospo-reusable-workflows#138:
1. release_discussion runs only after publish_release succeeds.
2. release_goreleaser auto-installs syft when GoReleaser config declares an sboms: block.

## Notes

- No caller-side configuration changes are required; v1.0.1 is backward-compatible with v1.0.0 inputs and secrets.
- This repo is a test harness for ospo-reusable-workflows itself, so keeping the pin current is the whole point.

## Testing

The next merged PR labeled release/feature/breaking/vuln will exercise the new fixes.